### PR TITLE
Update AdifContactRecord.cs to include submode

### DIFF
--- a/AdifLib/AdifContactRecord.cs
+++ b/AdifLib/AdifContactRecord.cs
@@ -65,6 +65,12 @@ namespace M0LTE.AdifLib
             set => SetField("mode", value);
         }
 
+        public string SubMode
+        {
+            get => Fields.TryGetValue("submode", out string value) ? value : null;
+            set => SetField("submode", value);
+        }
+
         public string RstSent
         {
             get => Fields.TryGetValue("rst_sent", out string value) ? value : null;


### PR DESCRIPTION
While using this library to parse the ADIF log from WSJT-X I found that submode is not available.